### PR TITLE
feat: create migration for database

### DIFF
--- a/config/autoload/databases.php
+++ b/config/autoload/databases.php
@@ -9,12 +9,13 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 use function Hyperf\Support\env;
 
 return [
     'default' => [
         'driver' => env('DB_DRIVER', 'mysql'),
-        'host' => env('DB_HOST', 'localhost'),
+        'host' => env('DB_HOST', 'mysql'),
         'database' => env('DB_DATABASE', 'hyperf'),
         'port' => env('DB_PORT', 3306),
         'username' => env('DB_USERNAME', 'root'),

--- a/migrations/2025_08_17_092515_create_notifications_table.php
+++ b/migrations/2025_08_17_092515_create_notifications_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('notifications', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->datetimes();
+            $table->timestamps();
             $table->string('channel');
             $table->string('recipient');
             $table->string('subject')->nullable();

--- a/migrations/2025_08_17_092515_create_notifications_table.php
+++ b/migrations/2025_08_17_092515_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Hyperf\Database\Schema\Schema;
+use Hyperf\Database\Schema\Blueprint;
+use Hyperf\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->datetimes();
+            $table->string('channel');
+            $table->string('recipient');
+            $table->string('subject')->nullable();
+            $table->text('body');
+            $table->string('status')->default('pending');
+            $table->string('source_system')->nullable();
+            $table->integer('retry_counts')->default(0);
+            $table->dateTime('scheduled_at')->nullable();
+            $table->dateTime('processing_at')->nullable();
+            $table->dateTime('sent_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};


### PR DESCRIPTION
This pull request introduces a new database migration for notifications and updates the default database host configuration. The most significant change is the creation of the `notifications` table, which will support tracking notification delivery and status.

**Database migration:**

* Added a new migration file `migrations/2025_08_17_092515_create_notifications_table.php` that creates a `notifications` table with fields for channel, recipient, subject, body, status, source system, retry counts, and various timestamps for scheduling and delivery.

**Configuration update:**

* Changed the default database host in `config/autoload/databases.php` from `'localhost'` to `'mysql'`, which may affect local development and deployment environments.