### PR TITLE
Feat/add notification service

### DIFF
--- a/app/Dto/NotificationDto.php
+++ b/app/Dto/NotificationDto.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NotificationService\App\Dto;
+
+use DateTime;
+
+class NotificationDto
+{
+
+    private string $channel;
+    private string $recipient;
+    private ?string $subject;
+    private string $body;
+    private ?DateTime $scheduled_at;
+
+    public function __construct(
+        string $channel,
+        string $recipient,
+        ?string $subject,
+        string $body,
+        ?DateTime $scheduled_at
+    ) {
+        $this->channel = $channel;
+        $this->recipient = $recipient;
+        $this->subject = $subject;
+        $this->body = $body;
+        $this->scheduled_at = $scheduled_at;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'channel' => $this->channel,
+            'recipient' => $this->recipient,
+            'subject' => $this->subject,
+            'body' => $this->body,
+            'scheduled_at' => $this->scheduled_at,
+        ];
+    }
+}

--- a/app/Model/NotificationModel.php
+++ b/app/Model/NotificationModel.php
@@ -23,7 +23,7 @@ use Hyperf\DbConnection\Model\Model;
  * @property Carbon $updated_at
  */
 
-class Notification extends Model
+class NotificationModel extends Model
 {
 
     protected ?string $table = 'notifications';

--- a/app/Service/Interfaces/NotificationServiceInterface.php
+++ b/app/Service/Interfaces/NotificationServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NotificationService\App\Service\Interfaces;
+
+use NotificationService\App\Dto\NotificationDto;
+use NotificationService\App\Model\Notification;
+
+interface NotificationServiceInterface
+{
+    public function createNotification(NotificationDto $dto): void;
+}

--- a/app/Service/NotificationService.php
+++ b/app/Service/NotificationService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NotificationService\App\Service;
+
+use NotificationService\App\Dto\NotificationDto;
+use NotificationService\App\Model\NotificationModel;
+use NotificationService\App\Service\Interfaces\NotificationServiceInterface;
+
+class NotificationService implements NotificationServiceInterface
+{
+
+    private NotificationModel $notificationModel;
+
+    public function __construct(NotificationModel $notificationModel)
+    {
+        $this->notificationModel = $notificationModel;
+    }
+
+    public function createNotification(NotificationDto $dto): void
+    {
+        $data = $dto->toArray();
+
+        $this->notificationModel::create($data);
+    }
+}


### PR DESCRIPTION
This pull request introduces a foundational refactor and new features to the notification service, focusing on improved structure, extensibility, and separation of concerns. The main changes include the creation of a dedicated DTO for notifications, the introduction of a service layer with a clear interface, and the renaming of the notification model for consistency.

**Notification Data Transfer and Service Layer**

* Added a new `NotificationDto` class to encapsulate notification data, improving type safety and decoupling data from persistence logic.
* Implemented a `NotificationService` class and its corresponding interface, `NotificationServiceInterface`, to handle notification creation via the DTO, promoting separation of concerns and future extensibility. [[1]](diffhunk://#diff-b794f67a6cdd7548312e2d59275f255cf8f62cdfbe983537d78dc2e9f658e188R1-R27) [[2]](diffhunk://#diff-843b6b90b82eed11c11884587f935f222d23017ce52b88b32c86c3423cdf2e78R1-R13)

**Model Consistency and Naming**

* Renamed the model from `Notification` to `NotificationModel` for clarity and consistency with service naming conventions.